### PR TITLE
Fix setting resource prefix

### DIFF
--- a/build_icons/README.md
+++ b/build_icons/README.md
@@ -16,10 +16,17 @@ And in your `build.rs` file, use `relm4-icons-build` to bundle the icons and inc
 ```rust
 fn main() {
     relm4_icons_build::bundle_icons(
+        // Name of the file that will be generated at `OUT_DIR`
         "icon_names.rs",
+        // Optional app ID
         Some("com.example.myapp"),
-        Some("icons"),
+        // Custom base resource path:
+        // * defaults to `/com/example/myapp` in this case if not specified explicitly
+        // * or `/org/relm4` if app ID was not specified either
         None::<&str>,
+        // Directory with custom icons (if any)
+        None::<&str>,
+        // List of icons to include
         [
             "ssd",
             "size-horizontally",

--- a/build_icons/src/lib.rs
+++ b/build_icons/src/lib.rs
@@ -17,7 +17,7 @@ pub mod constants {
         include_str!(concat!(env!("OUT_DIR"), "/shipped_icons.txt"));
 }
 
-const GENERAL_PREFIX: &str = "/org/relm4/icons/scalable/actions/";
+const GENERAL_PREFIX: &str = "/org/relm4/icons";
 
 /// Convert file name to icon name
 pub fn path_to_icon_name(string: &OsStr) -> String {
@@ -93,9 +93,9 @@ pub fn bundle_icons<P, I, S>(
     }
 
     let prefix = if let Some(base_resource_path) = &base_resource_path {
-        format!("{}/icons/scalable/actions/", base_resource_path)
+        format!("{}/icons", base_resource_path)
     } else if let Some(app_id) = app_id {
-        format!("/{}/icons/scalable/actions/", app_id.replace('.', "/"))
+        format!("/{}/icons", app_id.replace('.', "/"))
     } else {
         GENERAL_PREFIX.into()
     };
@@ -107,7 +107,7 @@ pub fn bundle_icons<P, I, S>(
             .iter()
             .map(|(icon, path)| {
                 GResourceFileData::from_file(
-                    format!("{prefix}{icon}-symbolic.svg"),
+                    format!("{prefix}/scalable/actions/{icon}-symbolic.svg"),
                     path,
                     true,
                     &PreprocessOptions::xml_stripblanks(),


### PR DESCRIPTION
Resource prefix was not set correctly.

I also updated readme of the build crate to make it similar to the main readme.

With this things work as expected, should be ready for release.