### PR TITLE
add option to prefix bundled icon names

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ fn main() {
             "size-horizontally",
             "cross",
         ],
+        // prefix for the bundled icons' identifiers
+        None::<&str>,
     );
 }
 ```


### PR DESCRIPTION
hi hi hello!

I am hereby proposing this change and also providing an MVP implementation, hopeful to have this merged before 0.10.0 is released:

in order to follow best practices when bundling custom icons with a gtk app, it is advised to use an app specific prefix. for example, [this is the way Tuba does it](https://github.com/GeopJr/Tuba/tree/main/data/icons/scalable/actions) (a `tuba-` prefix on each .svg file).

the rationale is: as pointed out in #13/#29, the system icon theme gets priority over the bundled icons. if the identifiers are the same, this can lead to fun surprises when the icons in the system icon theme change, [like this for example](https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/issues/259#note_1858116).

while it is currently possible to achieve the same thing by settings an `icons_folder` when calling the `bundle_icons` function in the build script, this is the only way to do it, so while all icons are always bundled, using a prefix requires you to manually bundle the svgs, which imo kinda defeats the point of the relm4-icons crate.

this PR adds an extra parameter with an optional prefix to the `bundle_icons` function. if set to `None`, the previous behavior is retained exactly as-is, so if someone *wants* to prefer the system icons, they still can. if set to `Some(prefix)`, each icon's identifier (but not const name) gets prepended with `prefix`.

I have also updated the README to reflect this change.

this change goes hand in hand with #29, both should be merged together.

let me know if there's anything else I missed here :) I would be open to changing the order of parameters so the prefix comes before the icon_names and icon_folder parameter, for example.