### PR TITLE
Add support for colored icons

### DIFF
--- a/build_icons/src/lib.rs
+++ b/build_icons/src/lib.rs
@@ -7,14 +7,12 @@ use std::fs;
 use std::fs::File;
 use std::io::BufWriter;
 use std::io::Write;
-use std::panic;
 use std::path::{Path, PathBuf};
 
 use gvdb::gresource::{BundleBuilder, FileData, PreprocessOptions};
 
 /// Stores data for each icon:
 /// - `path`: actual location on disk
-/// - `is_symbolic`: true if this should be treated as a symbolic icon
 /// - `is_shipped`: true if this icon is part of the shipped set
 struct IconData {
     path: PathBuf,


### PR DESCRIPTION
Like https://github.com/Relm4/icons/pull/46, this PR adds support for colored icons, but with simpler logic.
This is achieved by treating shipped icons as symbolic internally while allowing custom icons to retain their original color state based on the filename.