### PR TITLE
fix(clippy): fix clippy warning in output file

### DIFF
--- a/build_icons/src/lib.rs
+++ b/build_icons/src/lib.rs
@@ -247,7 +247,7 @@ pub fn bundle_icons<P, I, S>(
         writeln!(out_file, "}}").unwrap();
         write!(
             out_file,
-            "/// GResource file contents\n\
+            "/// `GResource` file contents\n\
             pub const GRESOURCE_BYTES: &[u8] = include_bytes!(\"{gresource_file_name}\");\n\
             /// Resource prefix used in generated `.gresource` file\n\
             pub const RESOURCE_PREFIX: &str = \"{prefix}\";"


### PR DESCRIPTION
Warning previously generated by clippy:

```
   |
69 | /// GResource file contents
   |     ^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
   = note: `-W clippy::doc-markdown` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::doc_markdown)]`
help: try
   |
69 - /// GResource file contents
69 + /// `GResource` file contents
   |
```
