### PR TITLE
build(deps): bump gtk to v0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ categories.workspace = true
 exclude = ["source/"]
 
 [dependencies]
-gtk = { version = "0.10", package = "gtk4" }
+gtk = { version = "0.11", package = "gtk4" }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
`gtk` is now `0.11` so I though it would be good to have this bump :smile: 