### PR TITLE
Bump `build_icons` `toml` to 1.1.0

### DIFF
--- a/build_icons/Cargo.toml
+++ b/build_icons/Cargo.toml
@@ -18,5 +18,5 @@ categories.workspace = true
 [dependencies]
 gvdb = { version = "0.10.0", features = ["gresource"] }
 serde = { version = "1.0.219", features = ["derive"] }
-toml = { version = "1.0.3" }
+toml = { version = "1.1.0" }
 walkdir = "2.5.0"


### PR DESCRIPTION
Increases `build_icons`' `toml` dependency to version 1.1.0.

(Semi-related question: the [current version of `build_icons` on crates.io](https://crates.io/crates/relm4-icons-build) is 0.10. Is an update in order? I'm using 0.10 along with `relm4-icons` 0.11 and it seems to work fine, so I'm not sure whether an update is necessary)